### PR TITLE
fix(chat): use serde default to deserialise None finish reason

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -764,7 +764,7 @@ pub struct ChatChoiceStream {
     /// The index of the choice in the list of choices.
     pub index: u32,
     pub delta: ChatCompletionStreamResponseDelta,
-    #[serde(deserialize_with = "deserialize_finish_reason")]
+    #[serde(default, deserialize_with = "deserialize_finish_reason")]
     pub finish_reason: Option<FinishReason>,
     /// Log probability information for the choice.
     pub logprobs: Option<ChatChoiceLogprobs>,


### PR DESCRIPTION
before:

![CleanShot X 2025-02-20 11 50 31](https://github.com/user-attachments/assets/c3566386-4e98-4d70-999c-c906aa15959c)

After:

![CleanShot X 2025-02-20 11 54 36](https://github.com/user-attachments/assets/ac081c37-5f2e-4299-953e-c5512d426a0f)
